### PR TITLE
COBOL and GnuCOBOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.0 | 2021-10-08
+- it's a web extension
+
 ## 0.1.2 | 2021-07-20
 - update icon
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-Cobol Folding
+COBOL Folding
 ================
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/zokugun.cobol-folding.svg)](https://marketplace.visualstudio.com/items?itemName=zokugun.cobol-folding)
 [![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/zokugun.cobol-folding.svg)](https://marketplace.visualstudio.com/items?itemName=zokugun.cobol-folding)
 
-Add foldings to Cobol files
+Add foldings to COBOL source files
 
 ## Configuration
 
 By default, the foldings are enabled.
 
-But you can disable the foldings, for a project, with the following config:
+But you can disable the foldings for a project, with the following workspace configuration:
 
 ```
 "cobolFolding.enabled": false // true, by default

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "cobol-folding",
-	"version": "0.1.2",
+	"version": "0.2.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "cobol-folding",
 	"displayName": "Cobol Folding",
 	"description": "Add foldings to Cobol files",
-	"version": "0.1.2",
+	"version": "0.2.0",
 	"author": {
 		"name": "Baptiste Augrain",
 		"email": "daiyam@zokugun.org"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "cobol-folding",
-	"displayName": "Cobol Folding",
-	"description": "Add foldings to Cobol files",
+	"displayName": "COBOL Folding",
+	"description": "Add foldings to COBOL files",
 	"version": "0.2.0",
 	"author": {
 		"name": "Baptiste Augrain",
@@ -57,12 +57,13 @@
 		"zokugun.explicit-folding"
 	],
 	"activationEvents": [
-		"onLanguage:cobol"
+		"onLanguage:cobol",
+		"onLanguage:gnucobol"
 	],
 	"contributes": {
 		"configuration": {
 			"type": "object",
-			"title": "Cobol Folding configuration",
+			"title": "COBOL Folding configuration",
 			"properties": {
 				"cobolFolding.enabled": {
 					"type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ async function showWhatsNewMessage(version: string) { // {{{
 	}];
 
 	const result = await vscode.window.showInformationMessage(
-		`Cobol Folding has been updated to v${version} — check out what's new!`,
+		`COBOL Folding has been updated to v${version} — check out what's new!`,
 		...actions,
 	);
 


### PR DESCRIPTION
* changing references from "Cobol" to the acronym COBOL   (some people find one spelling "offending", others the other...)
* adding activation for language gnucobol which is used in some other extensions (hm, uppercase "COBOL" is also used and may be reasonable to add; there are also more but I don't care that much about those ;-)